### PR TITLE
Allow empty value for string, false on boolean values on Custom Attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: go
 
-install:
-  - go get -d -v .
-
 script:
-  - go build -v ./
-
+  - env GO111MODULE=on go test -v .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM swaggerapi/swagger-codegen-cli:2.4.15
 
 COPY ecom.patch build/
+COPY model_catalog_custom_attribute_value.patch build/
 COPY open-api-3_square build/
 
 # Download swagger-codegen-cli 3.0.21 since I didn't find any Docker image
@@ -10,7 +11,9 @@ RUN apk add curl jq go && \
     cat open-api-3_square | jq '.data.attributes["json-spec"] | fromjson' > square-connect-openapi.json && \
     patch < ecom.patch && \
     mkdir square-connect-sdk && \
-    java -jar ./swagger-codegen-cli.jar generate -i square-connect-openapi.json -l go -o square-connect-sdk
+    java -jar ./swagger-codegen-cli.jar generate -i square-connect-openapi.json -l go -o square-connect-sdk && \
+    cd square-connect-sdk && \
+    patch < ../model_catalog_custom_attribute_value.patch
 
 # fix some issues with Swagger. TODO: file an issue
 RUN cd build/square-connect-sdk && \

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,6 @@ go 1.14
 
 require (
 	github.com/antihax/optional v1.0.0
+	github.com/stretchr/testify v1.4.0
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 )

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -102,13 +103,17 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -349,8 +354,10 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/model_catalog_custom_attribute_value.patch
+++ b/model_catalog_custom_attribute_value.patch
@@ -1,0 +1,19 @@
+--- original/model_catalog_custom_attribute_value.go	2021-03-25 16:53:52.000000000 -0700
++++ model_catalog_custom_attribute_value.go	2021-03-25 16:54:18.000000000 -0700
+@@ -14,14 +14,14 @@
+ 	// The name of the custom attribute.
+ 	Name string `json:"name,omitempty"`
+ 	// The string value of the custom attribute.  Populated if `type` = `STRING`.
+-	StringValue string `json:"string_value,omitempty"`
++	StringValue string `json:"string_value"`
+ 	// __Read-only.__ The id of the [CatalogCustomAttributeDefinition](#type-CatalogCustomAttributeDefinition) this value belongs to.
+ 	CustomAttributeDefinitionId string `json:"custom_attribute_definition_id,omitempty"`
+ 	Type_ *CatalogCustomAttributeDefinitionType `json:"type,omitempty"`
+ 	// Populated if `type` = `NUMBER`. Contains a string representation of a decimal number, using a `.` as the decimal separator.
+ 	NumberValue string `json:"number_value,omitempty"`
+ 	// A `true` or `false` value. Populated if `type` = `BOOLEAN`.
+-	BooleanValue bool `json:"boolean_value,omitempty"`
++	BooleanValue bool `json:"boolean_value"`
+ 	// One or more choices from `allowed_selections`. Populated if `type` = `SELECTION`.
+ 	SelectionUidValues []string `json:"selection_uid_values,omitempty"`
+ 	// __Read-only.__ A copy of key from the associated `CatalogCustomAttributeDefinition`.

--- a/patches_test.go
+++ b/patches_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/square/square-connect-go-sdk/swagger"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEcomPatch(t *testing.T) {
+	s := swagger.CatalogItem{}
+	// Ensure that Ecom fields exist. As long as the test compiles we are good and don't need any assertions.
+	s.EcomUri = "xyz"
+	s.EcomImageUris = []string{"xyz"}
+	s.EcomAvailable = true
+	s.EcomVisibility = "xyz"
+}
+
+func TestModelCatalogCustomAttributeValuePatch(t *testing.T) {
+	s := swagger.CatalogCustomAttributeValue{
+		StringValue:  "",
+		BooleanValue: false,
+	}
+	// Ensure that omitempty has been removed
+	json, err := json.Marshal(s)
+	require.NoError(t, err)
+	require.Equal(t, "{\"string_value\":\"\",\"boolean_value\":false}", string(json))
+}

--- a/swagger/model_catalog_custom_attribute_value.go
+++ b/swagger/model_catalog_custom_attribute_value.go
@@ -14,14 +14,14 @@ type CatalogCustomAttributeValue struct {
 	// The name of the custom attribute.
 	Name string `json:"name,omitempty"`
 	// The string value of the custom attribute.  Populated if `type` = `STRING`.
-	StringValue string `json:"string_value,omitempty"`
+	StringValue string `json:"string_value"`
 	// __Read-only.__ The id of the [CatalogCustomAttributeDefinition](#type-CatalogCustomAttributeDefinition) this value belongs to.
 	CustomAttributeDefinitionId string                                `json:"custom_attribute_definition_id,omitempty"`
 	Type_                       *CatalogCustomAttributeDefinitionType `json:"type,omitempty"`
 	// Populated if `type` = `NUMBER`. Contains a string representation of a decimal number, using a `.` as the decimal separator.
 	NumberValue string `json:"number_value,omitempty"`
 	// A `true` or `false` value. Populated if `type` = `BOOLEAN`.
-	BooleanValue bool `json:"boolean_value,omitempty"`
+	BooleanValue bool `json:"boolean_value"`
 	// One or more choices from `allowed_selections`. Populated if `type` = `SELECTION`.
 	SelectionUidValues []string `json:"selection_uid_values,omitempty"`
 	// __Read-only.__ A copy of key from the associated `CatalogCustomAttributeDefinition`.


### PR DESCRIPTION
Reference: https://developer.squareup.com/docs/catalog-api/add-custom-attributes#add-a-custom-attribute-to-a-catalog-object -- allows empty string on attributes

 https://docs.connect.squareup.com/v2/api/specifications/open-api-3_square