### PR TITLE
Add omitempty to Order.LocationId

### DIFF
--- a/swagger/model_order.go
+++ b/swagger/model_order.go
@@ -14,7 +14,7 @@ type Order struct {
 	// The order's unique ID.
 	Id string `json:"id,omitempty"`
 	// The ID of the seller location that this order is associated with.
-	LocationId string `json:"location_id"`
+	LocationId string `json:"location_id,omitempty"`
 	// A client-specified ID to associate an entity in another system with this order.
 	ReferenceId string       `json:"reference_id,omitempty"`
 	Source      *OrderSource `json:"source,omitempty"`


### PR DESCRIPTION
`Order.LocationId` should have the `omitempty` flag, this is because for `UpdateOrderRequest` used by `OrdersApi.UpdateOrder`, the `LocationId` is readonly and cannot be changed.

For example, this change should resolve the following error when calling Square UpdateOrder endpoint:

```
{
  "errors": [
    {
      "code": "INVALID_VALUE",
      "detail": "Immutable field cannot be changed.",
      "field": "order.location_id",
      "category": "INVALID_REQUEST_ERROR"
    }
  ]
}