### PR TITLE
Do not omitempty on a valid zero value for `Amount`

### DIFF
--- a/swagger/model_money.go
+++ b/swagger/model_money.go
@@ -12,6 +12,6 @@ package swagger
 // Represents an amount of money. `Money` fields can be signed or unsigned. Fields that do not explicitly define whether they are signed or unsigned are considered unsigned and can only hold positive amounts. For signed fields, the sign of the value indicates the purpose of the money transfer. See [Working with Monetary Amounts](https://developer.squareup.com/docs/build-basics/working-with-monetary-amounts) for more information.
 type Money struct {
 	// The amount of money, in the smallest denomination of the currency indicated by `currency`. For example, when `currency` is `USD`, `amount` is in cents. Monetary amounts can be positive or negative. See the specific field description to determine the meaning of the sign in a particular case.
-	Amount   int64     `json:"amount,omitempty"`
+	Amount   int64     `json:"amount"`
 	Currency *Currency `json:"currency,omitempty"`
 }


### PR DESCRIPTION
This bug was noticed as part of using the `CreateOrder` API with Modifications specified.

# Example Object and Response
```
(dlv) p lineItems[0].Modifiers[0].BasePriceMoney
*github.com/square/square-connect-go-sdk/swagger.Money {
	Amount: 0,
	Currency: *"USD",}
```

```
400 Bad Request: {\"errors\": [{\"code\": \"MISSING_REQUIRED_PARAMETER\",\"detail\": \"Missing required parameter.\",\"field\": \"order.line_items[0].modifiers[0].base_price_money.amount\",\"category\": \"INVALID_REQUEST_ERROR\"}]}\n
```

# API Docs:
https://developer.squareup.com/reference/square/orders-api/create-order

Thanks!
